### PR TITLE
adds modal dialog for user to confirm deletion

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@headlessui/react": "^1.7.18",
         "@tinymce/tinymce-react": "^4.3.2",
         "cloudinary": "^1.41.0",
         "html-react-parser": "^5.1.1",
@@ -817,6 +818,22 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.18",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.18.tgz",
+      "integrity": "sha512-4i5DOrzwN4qSgNsL4Si61VMkUcWbcSKueUV7sFhpHzQcSShdlHENE5+QBntMSRvHt8NyoFO2AGG8si9lq+w4zQ==",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
@@ -939,6 +956,31 @@
       "integrity": "sha512-ACXpdMM9hmKZww21yEqWwiLws/UPLhNKvimN8RrYSqPSvB3ov7sLvAcfvaxePeLvccTQKGdkDIhLYApZVDFuKg==",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.0.4.tgz",
+      "integrity": "sha512-tiqKW/e2MJVCr7/pRUXulpkyxllaOclkHNfhKTo4pmHjJIqnhMfwIjc1Q1R0Un3PI3kQywywu/791c8z9u0qeA==",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.0.0.tgz",
+      "integrity": "sha512-SYXOBTjJb05rXa2vl55TTwO40A6wKu0R5i1qQwhJYNDIqaIGF7D0HsLw+pJAyi2OvntlEIVusx3xtbbgSUi6zg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tinymce/tinymce-react": {
@@ -1446,6 +1488,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cloudinary": {
       "version": "1.41.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@headlessui/react": "^1.7.18",
     "@tinymce/tinymce-react": "^4.3.2",
     "cloudinary": "^1.41.0",
     "html-react-parser": "^5.1.1",

--- a/client/src/App.css
+++ b/client/src/App.css
@@ -26,3 +26,8 @@ main {
 .brand-title {
   letter-spacing: 2px;
 }
+
+body.modal-open {
+  overflow: hidden;
+  position: fixed;
+}

--- a/client/src/components/EditDeleteBar/EditDeleteBar.jsx
+++ b/client/src/components/EditDeleteBar/EditDeleteBar.jsx
@@ -1,19 +1,37 @@
-
+import { useState } from 'react'
+import PropTypes from 'prop-types'
+import Modal from '../Modal'
 export default function EditDeleteBar({ handleDeletePlant}) {
+
+  const [openModal, setOpenModal] = useState(false)
+
+  const toggleModal = () => {
+    setOpenModal(!openModal)
+  }
+
   return (
     <>
-    <div className="flex justify-end">
-      <button
-        className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 me-3 rounded">
-        Edit
-      </button>
-      <button
-        className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
-        onClick={handleDeletePlant}
-        >
-        Delete
-      </button>
-    </div>
+      <div className="flex justify-end">
+        <button
+          className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 me-3 rounded">
+          Edit
+        </button>
+        <button
+          className="bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded"
+          onClick={toggleModal}
+          >
+          Delete
+        </button>
+      </div>
+      <Modal
+        handleDeletePlant={handleDeletePlant}
+        openModal={openModal}
+        toggleModal={toggleModal}
+      />
     </>
   )
+}
+
+EditDeleteBar.propTypes = {
+  handleDeletePlant: PropTypes.func.isRequired
 }

--- a/client/src/components/Modal.jsx
+++ b/client/src/components/Modal.jsx
@@ -1,0 +1,54 @@
+
+import PropTypes from 'prop-types'
+import { IoMdClose } from "react-icons/io"
+const Modal = ({ handleDeletePlant, openModal, toggleModal }) => {
+
+  return (
+    <>
+        {openModal && (
+          <div
+            className={`fixed inset-0 flex justify-center items-center transition-colors ${openModal ? "bg-black/30 modal-open" : ""} `}
+            onClick={toggleModal}
+          >
+            <div
+              className="bg-white rounded-xl p-6 shadow transition-all relative"
+              onClick={(e) => e.stopPropagation()}
+            >
+            <header className="flex justify-around">
+              <h2 className="text-2xl mt-8 mb-0">Are you sure you want to delete this plant?</h2>
+              <button
+                className="text-gray-500 absolute top-2 right-2 hover:text-red-700 transition-colors"
+                onClick={toggleModal}>
+                <IoMdClose size={24} />
+              </button>
+            </header>
+            <div
+              className={`flex justify-center gap-5 pt-8 ${openModal ? "scale-100 opacity-100" : "scale-125 opacity-0"}`}>
+              <button
+                className="bg-gray-500 hover:bg-gray-600 shadow text-white font-bold py-2 px-4 rounded"
+                onClick={toggleModal}
+                >
+                Cancel
+                </button>
+                <button
+                  className="bg-red-500 hover:bg-red-700 shadow text-white font-bold py-2 px-4 rounded"
+                  onClick={handleDeletePlant}
+                  >
+                  Yes, delete
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+    </>
+  )
+}
+
+export default Modal
+
+Modal.propTypes = {
+  handleDeletePlant: PropTypes.func.isRequired,
+  openModal: PropTypes.bool,
+  setOpenModal: PropTypes.func.isRequired,
+  toggleModal: PropTypes.func.isRequired
+}


### PR DESCRIPTION
### Delete confirmation dialog modal

This PR adds a modal so that the admin user must confirm their intent to delete a plant from the database.

There are various libraries that provide this functionality (such as headless UI and Google's Material Design) but as the modal will only be used in this use case I decided to code it. 

![Screenshot 2024-02-06 at 15 20 59](https://github.com/wesonweb/houseyourplants_app/assets/6653884/c3842dcb-406d-40bb-bd97-200299d17972)

This closes #28 